### PR TITLE
Add additional proper names from TOPOLOGY_CIF

### DIFF
--- a/capitalisation.jl
+++ b/capitalisation.jl
@@ -15,8 +15,9 @@ const proper_names = ("Wyckoff","Cartn","_H_M\$","_H_M_","_Hall",
                       "ASTM","ISSN","^COD\$","NCA","^NH","MDF","NBS","PDB","PDF",
                       "I_over_I","I_over_netI","I_net","R_Fsqd","^R_I_","Lp_factor",
                       "R_I_factor","I_over_suI","meas_F","_S_",
-                      "^R\$","^RT\$","^T\$","^B\$","^Ro\$","EPINET",
-                      "RCSR","_SP\$","TOPOS\$","^Dsize\$"
+                      "^R\$","^RT\$","^T\$","^B\$","^Ro\$","EPINET","_IZA\$",
+                      "RCSR","_SP\$","TOPOS\$","^TD10\$","Z_number","Voronoi",
+                      "^D_size\$","^Dsize\$"
                       )
 
 mutable struct CapitalCheck <: Visitor_Recursive


### PR DESCRIPTION
This PR adds "IZA", "TD10", "Z_number", "Voronoi" and "D_size" to the proper name list since these terms appear in the `TOPOLOGY_CIF` dictionary.

Note, that "D_size" is the alternative spelling of "Dsize" that will be needed once the data item is renamed.