### PR TITLE
Add Lerche to the Julia package list in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Command-line tools for working with Crystallographic Information Framework files
 # Installation
 
 1.  [Install Julia](https://docs.julialang.org/en/v1/manual/getting-started/)
-2.  At the Julia prompt, type `using Pkg;Pkg.add("CrystalInfoFramework");Pkg.add("ArgParse")`. Exit Julia.
+2.  At the Julia prompt, type `using Pkg;Pkg.add("CrystalInfoFramework");Pkg.add("ArgParse");Pkg.add("Lerche")`. Exit Julia.
 3.  Copy or clone this project to a suitable location on your system. The instructions below assume that you are
     executing from this location.
 4.  A help message for each of the programs below can be obtained by running `julia <program_file>` at your command prompt.


### PR DESCRIPTION
Lerche was requested as one of the dependencies when running `linter.jl` under Linux Mint 20.2.